### PR TITLE
Improve toke implementation

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,16 +22,15 @@ func Transport(base http.RoundTripper) http.RoundTripper {
 	return t
 }
 
-// RoundTrip fetchs IDToken(in remote) or LocalAccessToken(in local), copies request, and set
-// the token to Authorization Header.
-// LocalAccessToken is same result as `gcloud auth print-access-token` output.
+// RoundTrip issues a request with identity token required service-to-service authentication described in
+// https://cloud.google.com/run/docs/authenticating/service-to-service.
+// When failed to obtain the identity token from metadata API (e.g. in local environment), uses access token generated
+// from service account credentials.
 //
-// If Users want to use this package, the following implementation is required on remote server.
-//
-// 		token := extractToken(r.Header.Get("Authorization"))
-// 		if !verifyToken(token) {
-//			return fmt.Errorf("failed to verify token")
-// 		}
+// If uses service-to-serivce authentication, server that receives the request must be implemented to validate the token
+// added to Authorization header.
+// In case of identity token, verify the identity token using the public key provided by Google.
+// In case of access token, check the access token has permission to execute some operation requested by the receiver.
 func (t *transport) RoundTrip(ireq *http.Request) (*http.Response, error) {
 	token, err := t.token()
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ type transport struct {
 	base http.RoundTripper
 }
 
-// Transport is an implementation of RoundTripper with TokenSource required authentication service-to-service.
+// Transport is an implementation of RoundTripper required service-to-service authentication.
 // If base http RoundTripper is nil, it sets DefaultTransport.
 func Transport(base http.RoundTripper) http.RoundTripper {
 	t := &transport{

--- a/client.go
+++ b/client.go
@@ -9,8 +9,10 @@ type transport struct {
 	base http.RoundTripper
 }
 
-// Transport is an implementation of RoundTripper required service-to-service authentication.
-// If base http RoundTripper is nil, it sets DefaultTransport.
+// Transport is an implementation of http.RoundTripper for App Engine.
+// Users should generally create an http.Client using this transport required
+// service-to-service authentication.
+// If base http RoundTripper is nil, it sets http.DefaultTransport.
 func Transport(base http.RoundTripper) http.RoundTripper {
 	t := &transport{
 		base: base,
@@ -21,6 +23,9 @@ func Transport(base http.RoundTripper) http.RoundTripper {
 	return t
 }
 
+// RoundTrip is service-to-service authentication implementation.
+// It fetchs idToken(in remote) or accessToken(in local), and copy request with Authorization
+// Header which is setted the token.
 func (t *transport) RoundTrip(ireq *http.Request) (*http.Response, error) {
 	token, err := t.token()
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -10,8 +10,7 @@ type transport struct {
 }
 
 // Transport is an implementation of http.RoundTripper for App Engine.
-// Users should generally create an http.Client using this transport required
-// service-to-service authentication.
+// When required service-to-service authentication, create http.Client using this transport.
 // If base http RoundTripper is nil, it sets http.DefaultTransport.
 func Transport(base http.RoundTripper) http.RoundTripper {
 	t := &transport{

--- a/client.go
+++ b/client.go
@@ -23,9 +23,16 @@ func Transport(base http.RoundTripper) http.RoundTripper {
 	return t
 }
 
-// RoundTrip is service-to-service authentication implementation.
-// It fetchs idToken(in remote) or accessToken(in local), and copy request with Authorization
-// Header which is setted the token.
+// RoundTrip fetchs IDToken(in remote) or LocalAccessToken(in local), copies request, and set
+// the token to Authorization Header.
+// LocalAccessToken is same result as `gcloud auth print-access-token` output.
+//
+// If Users want to use this package, the following implementation is required on remote server.
+//
+// 		token := extractToken(r.Header.Get("Authorization"))
+// 		if !verifyToken(token) {
+//			return fmt.Errorf("failed to verify token")
+// 		}
 func (t *transport) RoundTrip(ireq *http.Request) (*http.Response, error) {
 	token, err := t.token()
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -1,6 +1,4 @@
-// package aehcl provides HTTP RoundTripper for authentication service-to-service
-// in Google App Engine.
-
+// Package aehcl provides service-to-service authentication in Google App Engine.
 package aehcl
 
 import (

--- a/client.go
+++ b/client.go
@@ -8,16 +8,14 @@ import (
 )
 
 type transport struct {
-	base  http.RoundTripper
-	token tokenSource
+	base http.RoundTripper
 }
 
 // Transport is an implementation of RoundTripper with TokenSource required authentication service-to-service.
 // If base http RoundTripper is nil, it sets DefaultTransport.
 func Transport(base http.RoundTripper) http.RoundTripper {
 	t := &transport{
-		base:  base,
-		token: token(),
+		base: base,
 	}
 	if base == nil {
 		t.base = http.DefaultTransport
@@ -41,6 +39,10 @@ func (t *transport) RoundTrip(ireq *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	return t.base.RoundTrip(req)
+}
+
+func (t *transport) token() (string, error) {
+	return fetchToken()
 }
 
 func cloneHeader(h http.Header) http.Header {

--- a/client_test.go
+++ b/client_test.go
@@ -39,6 +39,8 @@ func TestRoundTrip(t *testing.T) {
 				Transport: tt.arg,
 			}
 			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
 			client.Get(server.URL)
 		})
 	}

--- a/identity.go
+++ b/identity.go
@@ -11,8 +11,8 @@ import (
 
 func fetchToken() (string, error) {
 	// get idToken from metadata of gcp
-	if idToken, err := fetchIDToken(); err == nil {
-		return idToken, nil
+	if idt, err := fetchIDToken(); err == nil {
+		return idt, nil
 	}
 
 	// get accesstoken from local `GOOGLE_APPLICATION_CREDENTIALS`

--- a/identity.go
+++ b/identity.go
@@ -9,14 +9,6 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
-type tokenSource func() (string, error)
-
-func token() tokenSource {
-	return func() (string, error) {
-		return fetchToken()
-	}
-}
-
 func fetchToken() (string, error) {
 	// get idToken from metadata of gcp
 	if idToken, err := fetchIDToken(); err == nil {

--- a/identity.go
+++ b/identity.go
@@ -10,12 +10,12 @@ import (
 )
 
 func fetchToken() (string, error) {
-	// get idToken from metadata of gcp
+	// fetch idToken from metadata of gcp
 	if idt, err := fetchIDToken(); err == nil {
 		return idt, nil
 	}
 
-	// get accesstoken from local `GOOGLE_APPLICATION_CREDENTIALS`
+	// fetch accesstoken from local `GOOGLE_APPLICATION_CREDENTIALS`
 	lat, err := fetchLocalAccessToken()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## What

token 周りの実装を修正しました。

- tokenSource は外部から差し込む interface にしなくなったので削除
- fetch/get が混在しているのを fetch に統一
- idToken/lat が揃っていないので idt/lat に統一
- godoc を拡充
  - package docs の修正
  - Transport のドキュメントを詳細に記載
  - RoundTrip のドキュメントにて以下の2点を追加
    - tokenを取得すること
    - remote サーバーに token の検証を行う実装が必要なこと
- その他軽微な修正
  - テストでサーバーを落とす