### PR TITLE
ローカルのアクセストークンの取得実装を削除する

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ go get github.com/emahiro/aehcl
 ```go
 
 client := &http.Client {
-    Transport: aehcl.Transport(http.DefaultTransport, aehcl.FetchIDToken)
+    Transport: aehcl.Transport(http.DefaultTransport, aehcl.WithTokenSource(aehcl.FetchIDToken))
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ go get github.com/emahiro/aehcl
 ```go
 
 client := &http.Client {
-    Transport: aehcl.Transport(http.DefaultTransport)
+    Transport: aehcl.Transport(http.DefaultTransport, aehcl.FetchIDToken)
 }
 
 ```

--- a/client.go
+++ b/client.go
@@ -24,13 +24,10 @@ func Transport(base http.RoundTripper) http.RoundTripper {
 
 // RoundTrip issues a request with identity token required service-to-service authentication described in
 // https://cloud.google.com/run/docs/authenticating/service-to-service.
-// When failed to obtain the identity token from metadata API (e.g. in local environment), uses access token generated
-// from service account credentials.
+// When failed to obtain the identity token from metadata API (e.g. in local environment), RoundTrip returns error.
 //
-// If uses service-to-serivce authentication, server that receives the request must be implemented to validate the token
-// added to Authorization header.
-// In case of identity token, verify the identity token using the public key provided by Google.
-// In case of access token, check the access token has permission to execute some operation requested by the receiver.
+// If uses service-to-serivce authentication, server that receives the request must be implemented to validate the identity
+// token added to Authorization header using the public key provided by Google.
 func (t *transport) RoundTrip(ireq *http.Request) (*http.Response, error) {
 	token, err := t.token()
 	if err != nil {
@@ -50,7 +47,7 @@ func (t *transport) RoundTrip(ireq *http.Request) (*http.Response, error) {
 }
 
 func (t *transport) token() (string, error) {
-	return fetchToken()
+	return fetchIDToken()
 }
 
 func cloneHeader(h http.Header) http.Header {

--- a/client.go
+++ b/client.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 )
 
-// TokenSource is interface of function returns token required service-to-service authentication in App Engine.
+// TokenSource is function that returns token required service-to-service authentication in App Engine.
 type TokenSource func() (string, error)
 
-// Option is interface of function adds transport option required service-to-service authentication.
+// Option is function that adds transport option required service-to-service authentication.
 type Option func(*option)
 
 type option struct {

--- a/client.go
+++ b/client.go
@@ -5,16 +5,21 @@ import (
 	"net/http"
 )
 
+// TokenSource is interface of function returns token required service-to-service authentication in App Engine.
+type TokenSource func() (string, error)
+
 type transport struct {
 	base http.RoundTripper
+	ts   TokenSource
 }
 
 // Transport is an implementation of http.RoundTripper for App Engine.
 // When required service-to-service authentication, create http.Client using this transport.
 // If base http RoundTripper is nil, it sets http.DefaultTransport.
-func Transport(base http.RoundTripper) http.RoundTripper {
+func Transport(base http.RoundTripper, ts TokenSource) http.RoundTripper {
 	t := &transport{
 		base: base,
+		ts:   ts,
 	}
 	if base == nil {
 		t.base = http.DefaultTransport
@@ -47,7 +52,7 @@ func (t *transport) RoundTrip(ireq *http.Request) (*http.Response, error) {
 }
 
 func (t *transport) token() (string, error) {
-	return fetchIDToken()
+	return t.ts()
 }
 
 func cloneHeader(h http.Header) http.Header {

--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ type transport struct {
 // Transport is an implementation of http.RoundTripper for service-to-service authentication.
 // When required service-to-service authentication, create http.Client using this transport.
 //
-// Default RoundTripper is http.DefaultTransport, and Default TokenSourceOption is FetchIDToken.
+// Default RoundTripper is http.DefaultTransport, and default TokenSourceOption is FetchIDToken.
 func Transport(base http.RoundTripper, opts ...TokenSourceOption) http.RoundTripper {
 	t := &transport{
 		base: base,

--- a/client.go
+++ b/client.go
@@ -13,9 +13,9 @@ type transport struct {
 	ts   TokenSource
 }
 
-// Transport is an implementation of http.RoundTripper for App Engine.
+// Transport is an implementation of http.RoundTripper for service-to-service authentication.
 // When required service-to-service authentication, create http.Client using this transport.
-// If base http RoundTripper is nil, it sets http.DefaultTransport.
+// If base http RoundTripper is nil, http.DefaultTransport is assigned.
 func Transport(base http.RoundTripper, ts TokenSource) http.RoundTripper {
 	t := &transport{
 		base: base,
@@ -31,8 +31,8 @@ func Transport(base http.RoundTripper, ts TokenSource) http.RoundTripper {
 // https://cloud.google.com/run/docs/authenticating/service-to-service.
 // When failed to obtain the identity token from metadata API (e.g. in local environment), RoundTrip returns error.
 //
-// If uses service-to-serivce authentication, server that receives the request must be implemented to validate the identity
-// token added to Authorization header using the public key provided by Google.
+// If uses service-to-serivce authentication, server that receives the request must be implemented to validate the
+// identity token added to Authorization header using the public key provided by Google.
 func (t *transport) RoundTrip(ireq *http.Request) (*http.Response, error) {
 	token, err := t.token()
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -8,21 +8,21 @@ import (
 // TokenSource is interface of function returns token required service-to-service authentication in App Engine.
 type TokenSource func() (string, error)
 
-// TokenSourceOption is interface of function that sets token source required service-to-service authentication.
-type TokenSourceOption func(*tokenSourceOption)
+// Option is interface of function adds transport option required service-to-service authentication.
+type Option func(*option)
 
-type tokenSourceOption struct {
+type option struct {
 	token TokenSource
 }
 
-// WithTokenSource sets token source required service-to-service authentication to tokenSourceOption.
-func WithTokenSource(ts TokenSource) TokenSourceOption {
-	return func(o *tokenSourceOption) {
+// WithTokenSource sets token source required service-to-service authentication to transport option.
+func WithTokenSource(ts TokenSource) Option {
+	return func(o *option) {
 		o.token = ts
 	}
 }
 
-func (o *tokenSourceOption) apply(opts []TokenSourceOption) {
+func (o *option) apply(opts []Option) {
 	for _, opt := range opts {
 		opt(o)
 	}
@@ -36,9 +36,9 @@ type transport struct {
 // Transport is an implementation of http.RoundTripper for service-to-service authentication.
 // When required service-to-service authentication, create http.Client using this transport.
 //
-// Default RoundTripper is http.DefaultTransport, and default TokenSourceOption is FetchIDToken.
-func Transport(base http.RoundTripper, opts ...TokenSourceOption) http.RoundTripper {
-	opt := &tokenSourceOption{token: FetchIDToken}
+// Default RoundTripper is http.DefaultTransport, and FetchIDToken is assigned as default option.
+func Transport(base http.RoundTripper, opts ...Option) http.RoundTripper {
+	opt := &option{token: FetchIDToken}
 	opt.apply(opts)
 
 	t := &transport{

--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,6 @@
 package aehcl
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,7 +14,7 @@ func TestRoundTrip(t *testing.T) {
 	}{
 		{
 			name: "success to get authorization header",
-			arg:  Transport(http.DefaultTransport, FetchIDToken),
+			arg:  Transport(http.DefaultTransport, WithTokenSource(FetchIDToken)),
 			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if h := r.Header.Get("Authorization"); h == "" {
 					t.Fatalf("Authorization Header is required")
@@ -28,17 +27,6 @@ func TestRoundTrip(t *testing.T) {
 			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if h := r.Header.Get("Authorization"); h != "" {
 					t.Fatalf("Authorization Header is exist. header: %v", h)
-				}
-			}),
-		},
-		{
-			name: "faield to get idToken",
-			arg: Transport(http.DefaultTransport, func() (string, error) {
-				return "", fmt.Errorf("hoge")
-			}),
-			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r != nil {
-					t.Fatalf("request should be failed")
 				}
 			}),
 		},

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package aehcl
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +11,7 @@ func TestRoundTrip(t *testing.T) {
 	tests := []struct {
 		name    string
 		arg     http.RoundTripper
+		ts      func() (string, error)
 		handler http.Handler
 	}{
 		{
@@ -27,6 +29,17 @@ func TestRoundTrip(t *testing.T) {
 			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if h := r.Header.Get("Authorization"); h != "" {
 					t.Fatalf("Authorization Header is exist. header: %v", h)
+				}
+			}),
+		},
+		{
+			name: "faield to get idToken",
+			arg: Transport(http.DefaultTransport, func() (string, error) {
+				return "", fmt.Errorf("hoge")
+			}),
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r != nil {
+					t.Fatalf("request should be failed")
 				}
 			}),
 		},

--- a/client_test.go
+++ b/client_test.go
@@ -11,7 +11,6 @@ func TestRoundTrip(t *testing.T) {
 	tests := []struct {
 		name    string
 		arg     http.RoundTripper
-		ts      func() (string, error)
 		handler http.Handler
 	}{
 		{

--- a/client_test.go
+++ b/client_test.go
@@ -22,6 +22,15 @@ func TestRoundTrip(t *testing.T) {
 			}),
 		},
 		{
+			name: "success to get authorization header in empty options",
+			arg:  Transport(http.DefaultTransport, []Option{}...),
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if h := r.Header.Get("Authorization"); h == "" {
+					t.Fatalf("Authorization Header is required")
+				}
+			}),
+		},
+		{
 			name: "faield to get authorization header",
 			arg:  &http.Transport{},
 			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/client_test.go
+++ b/client_test.go
@@ -14,7 +14,7 @@ func TestRoundTrip(t *testing.T) {
 	}{
 		{
 			name: "success to get authorization header",
-			arg:  Transport(http.DefaultTransport),
+			arg:  Transport(http.DefaultTransport, FetchIDToken),
 			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if h := r.Header.Get("Authorization"); h == "" {
 					t.Fatalf("Authorization Header is required")

--- a/identity.go
+++ b/identity.go
@@ -1,44 +1,11 @@
 package aehcl
 
 import (
-	"context"
-	"fmt"
 	"os"
 
 	"cloud.google.com/go/compute/metadata"
-	"golang.org/x/oauth2/google"
 )
-
-func fetchToken() (string, error) {
-	// fetch idToken from metadata of gcp
-	if idt, err := fetchIDToken(); err == nil {
-		return idt, nil
-	}
-
-	// fetch accesstoken from local `GOOGLE_APPLICATION_CREDENTIALS`
-	lat, err := fetchLocalAccessToken()
-	if err != nil {
-		return "", err
-	}
-	return lat, nil
-}
 
 func fetchIDToken() (string, error) {
 	return metadata.Get("/instance/service-accounts/default/identity?audience=" + os.Getenv("GOOGLE_CLOUD_PROJECT"))
-}
-
-func fetchLocalAccessToken() (string, error) {
-	creds, err := google.FindDefaultCredentials(context.Background())
-	if err != nil {
-		return "", fmt.Errorf("failed to find default credentials. err: %v", err)
-
-	}
-
-	token, err := creds.TokenSource.Token()
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch token. err: %v", err)
-
-	}
-
-	return token.AccessToken, nil
 }

--- a/identity.go
+++ b/identity.go
@@ -6,6 +6,7 @@ import (
 	"cloud.google.com/go/compute/metadata"
 )
 
-func fetchIDToken() (string, error) {
+// FetchIDToken returns identity token from metadata API.
+func FetchIDToken() (string, error) {
 	return metadata.Get("/instance/service-accounts/default/identity?audience=" + os.Getenv("GOOGLE_CLOUD_PROJECT"))
 }


### PR DESCRIPTION
## これは何か？

ローカルのアクセストークンを取得する実装を削除します。

## なぜ削除するのか？

リモートのサーバーでは identity token を取得できるが、ローカルでは取得できないためにサービスアカウントの Credentials を使ってアクセストークンを生成して、それを利用してリクエストを投げてもらう予定でしたが、そうした場合、受けるサーバー側でアクセストークンの権限ごとにリクエストを通すか通さないかを柔軟に設定することができません。

そもそもローカルのアクセストークンを使ったリクエストは https://cloud.google.com/run/docs/authenticating/service-to-service に準拠した方式ではないため、これに含めるべきでないのでローカルアクセストークンを使った処理は削除します。

## 追加

### TransportOption

Transport を Newするタイミングで Option を指定します。このOption は token source を持ちます。

[functional Option pattern](https://commandcenter.blogspot.com/2014/01/self-referential-functions-and-design.html) を使います。

Transport を new するときに TokenSourceOption を slice にして引数に指定して Transport で Authorization Header にセットするtokenの中身を変更できるようにします。

TokenSourceOption が指定されない時はデフォルトで FetchIDToken をoption に指定します。

example

```go
opts := make([]aehcl.Option, 0, 2)
opts =  append(opts, aehcl.WithTokenSource(aehcl.FetchIDToken))
if isLocal {
    opts := append(opts, aehcl.WithTokenSource(localAccessToken)) // localの場合は上書きされてこちらが使われる。
} 

client := &http.Client{
    Transport: aehcl.Transport(nil, opts),
}
```

